### PR TITLE
Config consolidation mkII

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,36 +1,36 @@
 """
-This module serves to import user configurable data such as
-addresses of private API keys and provide them to HouseBot.
+This module provides configurable parameters which let the user
+tailor HouseBot's results to their preferences.
 """
-import json
 
-# Edit these two values with the location of your appropriate file.
-API_KEY_FILENAME = 'api_key.json'
-ADDRESSES_FILENAME = 'addresses.json'
+# A number of house specified attributes you can tune to
+# find the breed of property you want to call your home.
+house_search_parameters = {
+    'order_by': 'age',          # price, age
+    'ordering': '',             # descending (default), ascending
+    'listing_status': 'rent',
+    'area': 'London',
+    'minimum_price': '300',     # price per week
+    'maximum_price': '400',     # price per week
+    'minimum_beds': '3',
+    'maximum_beds': '4',
+    'furnished': '',            # furnished, unfurnished, part-furnished
+    'property_type': '',        # houses, flats
+    'page_number': '',          # the page number of results to request, default 1
+    'page_size': '100'          # the size of each page of results, default 10, maximum 100
+}
 
+# The maximum amount of time a property has been
+# 'live' for. Any properties that have been up for
+# longer are not included in the search. This is because
+# the searches will be conducted periodically and we don't
+# want to be swamped by 'old' results
+house_maximum_listing_age = 60 * 12  # In minutes
 
-def _import_data_from_json_file(file_name):
-    """
-    Imports JSON data from a local file.
-    :param file_name: Name of the file to import from
-    :return: Deserialized JSON data, else error
-    """
-
-    # read in the addresses from file
-    try:
-        with open(file_name) as f:
-            deserialized_data = json.load(f)
-
-        return deserialized_data
-    except IOError:
-        print ("Unable to find addresses. "
-               "Please ensure you have a %s file in the root directory"
-               % file_name)
-        exit()
-    except ValueError:
-        print "Unable to interpret %s file as valid JSON." % file_name
-        exit()
-
-
-user_addresses = _import_data_from_json_file(file_name=ADDRESSES_FILENAME)
-zoopla_api_key = _import_data_from_json_file(file_name=API_KEY_FILENAME)["zoopla_api_key"]
+# Work (or other destination!) addresses of the household-members-to-be.
+# HouseBot will check the travel time to each destination below
+# for each property that passes the search filtering.
+house_member_commuting_destinations = {
+  'Alice': '221b Baker Street, London NW1 6XE',
+  'Bob': 'Buckingham Palace, London SW1A 1AA'
+}

--- a/credentials.py
+++ b/credentials.py
@@ -1,0 +1,28 @@
+import json
+
+_API_CREDENTIALS_FILENAME = 'api_key.json'
+
+
+def _import_api_credentials(file_name):
+    """
+    Imports JSON data from a local file.
+    :param file_name: Name of the file to import from
+    :return: Deserialized JSON data, else error
+    """
+
+    # read in the addresses from file
+    try:
+        with open(file_name) as f:
+            deserialized_data = json.load(f)
+
+        return deserialized_data['zoopla_api_key']
+    except IOError:
+        print ("Unable to API key file at %s. Please double check it's in the correct place and try again."
+               % file_name)
+        exit()
+    except ValueError:
+        print "Unable to interpret %s file as valid JSON." % file_name
+        exit()
+
+zoopla_api_key = _import_api_credentials(file_name=_API_CREDENTIALS_FILENAME)
+

--- a/housebot.py
+++ b/housebot.py
@@ -4,28 +4,14 @@ import google_maps
 
 import config
 
+# Find all properties that match our housing requirements
+matching_properties_zoopla = zoopla.get_properties(
+    max_listing_age=config.house_maximum_listing_age,
+    params=config.house_search_parameters
+)
 
-ADDRESSES_FILENAME = 'addresses.json'
-
-max_listing_age = 60*12  # in minutes
-
-# construct params
-params = {
-    'order_by': 'age',          # price, age
-    'ordering': '',             # descending (default), ascending
-    'listing_status': 'rent',
-    'area': 'London',
-    'minimum_price': '300',     # price per week
-    'maximum_price': '400',     # price per week
-    'minimum_beds': '3',
-    'maximum_beds': '4',
-    'furnished': '',            # furnished, unfurnished, part-furnished
-    'property_type': '',        # houses, flats
-    'page_number': '',          # the page number of results to request, default 1
-    'page_size': '100'          # the size of each page of results, default 10, maximum 100
-}
-
-
-
-matching_properties_zoopla = zoopla.get_properties(max_listing_age, params)
-matching_properties = google_maps.get_time_to_work(matching_properties_zoopla, config.user_addresses)
+# Find the group's commute time to all properties that passed the filtering process.
+matching_properties = google_maps.get_time_to_work(
+    selected_properties=matching_properties_zoopla,
+    addresses=config.house_member_commuting_destinations
+)

--- a/readme.md
+++ b/readme.md
@@ -3,7 +3,7 @@
 A tool to get notifications of the latest houses in your area with travel information to various locations.
 
 ## Setting up Dev environment
-- create a new file api_key.json in the root directory of the project and add the Zoopla API key into it, i.e.
+- create a new file api_key.json in the root directory of the project and add your Zoopla API key into it, i.e.
 
 ```
 {
@@ -11,16 +11,9 @@ A tool to get notifications of the latest houses in your area with travel inform
 }
 ```
 
-- create a new file addresses.json and add the addresses you want to check for in json format, i.e
-
-```
-{
-    "name": "Address",
-    "name2": "Address"
-}
-```
+- investigate config.py and update it with housing preferences relevant for you
 
 - pip install -r requirements.txt
 
 ## Instructions
-- simply run housebot.py (any parameters for the listing details or age can be edited in manually housebot.py)
+- Simply run housebot.py (any parameters for the listing details or age can be edited in manually housebot.py)

--- a/zoopla.py
+++ b/zoopla.py
@@ -1,12 +1,12 @@
 __author__ = 'Kadi'
 import requests
-import json
 from datetime import datetime, time, timedelta
 
-import config
+import credentials
 
 
 BASE_ZOOPLA_URI = 'http://api.zoopla.co.uk/api/v1/property_listings.js'  # remove '.js' for xml output
+
 
 def get_properties(max_listing_age, params):
     # construct the parameter string to include the parameters that have values
@@ -16,11 +16,14 @@ def get_properties(max_listing_age, params):
             param_string += "{0}={1}&".format(param, params[param])
 
     # construct the url
-    url = "{0}?{1}api_key={2}".format(BASE_ZOOPLA_URI, param_string, config.zoopla_api_key)
+    url = "{0}?{1}api_key={2}".format(BASE_ZOOPLA_URI, param_string, credentials.zoopla_api_key)
 
     response = requests.get(url)
-    json_response = response._content       # json string
-    dict_data = json.loads(json_response)    # dictionary
+    if response.status_code == 403:
+        print 'Invalid Zoopla credentials! Please double check your Zoopla API key.'
+        exit()
+
+    dict_data = response.json()
 
     print('Url: ' + url)
 


### PR DESCRIPTION
Went a step further and extracted all the user-tunable stuff into config.py, meaning that housebot.py now only has its core functions. To keep credential secrecy, I have a different credentials module loading  any API keys.

The config file is heavily commented to make sure anyone can start using HouseBot to find the property they're after.

Additionally, streamlined a small amount of code in zoopla.py via knowledge of `python-requests` convenience methods.
